### PR TITLE
👷 ci: update deploy-pages action to v4

### DIFF
--- a/.github/workflows/page.yaml
+++ b/.github/workflows/page.yaml
@@ -48,4 +48,4 @@ jobs:
           path: build
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 🎯 Purpose

Update the GitHub Actions deploy-pages action to version 4 for improved functionality and performance.

## 💡 Notes

No breaking changes are introduced with this update.