### PR TITLE
📝 docs: add bash to powershell commands cheat sheet and resource sections

### DIFF
--- a/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
+++ b/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
@@ -103,7 +103,7 @@ PowerShell equivalents.
 | **Description**                 | **Bash Command**           | **PowerShell Equivalent**            | **Notes**                                           |
 | :------------------------------ | :------------------------- | :----------------------------------- | :-------------------------------------------------- |
 | Pipe output to file (overwrite) | `<command> > <file>`       | `<command> \| Out-File <file>`       |                                                     |
-| Pipe output to file (append)    | `<command> >> <file>`      | `command \| Out-File -Append <file>` |                                                     |
+| Pipe output to file (append)    | `<command> >> <file>`      | `<command> \| Out-File -Append <file>` |                                                     |
 | Pipe to another command         | `<command1> \| <command2>` | `<command1> \| <command2>`           | Works the same, but passes objects instead of text. |
 
 </div>

--- a/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
+++ b/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
@@ -1,0 +1,133 @@
+---
+title: "Bash to PowerShell: Commands Cheat Sheet"
+description:
+  A quick reference guide of common Bash commands and their PowerShell
+  equivalents.
+date: 2025-08-13T00:00:00Z
+tags:
+  - bash
+  - cheat-sheet
+  - productivity
+  - scripting
+  - sysadmin
+---
+
+# Bash to PowerShell: Commands Cheat Sheet
+
+This cheat sheet provides a quick reference of common Bash commands and their
+PowerShell equivalents.
+
+## File & Directory Navigation
+
+<div className="center">
+
+| **Description**                 | **Bash Command**   | **PowerShell Equivalent**                          | **Notes**                                               |
+| :------------------------------ | :----------------- | :------------------------------------------------- | :------------------------------------------------------ |
+| List files in current directory | `ls`               | `Get-ChildItem` or `ls`                            | `ls` is an alias in PowerShell, but formatting differs. |
+| List one item per line          | `ls -1`            | `Get-ChildItem -Name` or `gci -Name`               | Shows only names, one per line.                         |
+| Show current directory          | `pwd`              | `Get-Location` or `pwd`                            | `pwd` exists as alias.                                  |
+| Change directory                | `cd <destination>` | `Set-Location <destination>` or `cd <destination>` | `cd` is an alias.                                       |
+| Go up one directory             | `cd ..`            | `cd ..`                                            | Works the same in both.                                 |
+
+</div>
+
+## File Viewing
+
+<div className="center">
+
+| **Description**       | **Bash Command**   | **PowerShell Equivalent**                                                | **Notes**                       |
+| :-------------------- | :----------------- | :----------------------------------------------------------------------- | :------------------------------ |
+| View file contents    | `cat <file>`       | `Get-Content <file>` or `gc <file>` or `cat <file>`                      | `gc` and `cat` are aliases.     |
+| View first N lines    | `head -n N <file>` | `Get-Content -TotalCount N <file>`                                       | N = number of lines.            |
+| View last N lines     | `tail -n N <file>` | `Get-Content -Tail N <file>`                                             | N = number of lines.            |
+| View file with paging | `less <file>`      | `Get-Content <file> \| more` or `Get-Content <file> \| Out-Host -Paging` | PowerShell has no native pager. |
+
+</div>
+
+## File & Directory Management
+
+<div className="center">
+
+| **Description**              | **Bash Command**            | **PowerShell Equivalent**                                         | **Notes**            |
+| :--------------------------- | :-------------------------- | :---------------------------------------------------------------- | :------------------- |
+| Copy file                    | `cp <source> <destination>` | `Copy-Item <source> <destination>` or `cp <source> <destination>` | `cp` is an alias.    |
+| Move/rename file             | `mv <source> <destination>` | `Move-Item <source> <destination>` or `mv <source> <destination>` | `mv` is an alias.    |
+| Remove file                  | `rm <file>`                 | `Remove-Item <file>` or `rm <file>`                               | `rm` is an alias.    |
+| Create directory             | `mkdir <directory>`         | `New-Item -ItemType Directory <directory>` or `mkdir <directory>` | `mkdir` is an alias. |
+| Create empty file            | `touch <file>`              | `New-Item -ItemType File <file>`                                  |                      |
+| Delete directory recursively | `rm -r <directory>`         | `Remove-Item -Recurse <directory>`                                |                      |
+
+</div>
+
+## Search & Filtering
+
+<div className="center">
+
+| **Description**    | **Bash Command**              | **PowerShell Equivalent**                       | **Notes**                  |
+| :----------------- | :---------------------------- | :---------------------------------------------- | :------------------------- |
+| Find files by name | `find . -name <name/pattern>` | `Get-ChildItem -Recurse -Filter <name/pattern>` |                            |
+| Search inside file | `grep <pattern> <file>`       | `Select-String <pattern> <file>`                | Supports regex by default. |
+| Search recursively | `grep -r <pattern> .`         | `Select-String -Recurse <pattern> -Path . `     |                            |
+
+</div>
+
+## System Info & Environment
+
+<div className="center">
+
+| **Description**                  | **Bash Command**          | **PowerShell Equivalent**                       | **Notes**                   |
+| :------------------------------- | :------------------------ | :---------------------------------------------- | :-------------------------- |
+| Show command path                | `which <command>`         | `Get-Command <command> \| Select-Object Source` | Shows full path to command. |
+| Show environment variables       | `printenv`                | `Get-ChildItem Env:`                            |                             |
+| Set environment variable         | `export <name>="<value>"` | `$Env:<name> = "<value>"`                       |                             |
+| Show single environment variable | `echo $<name>`            | `$Env:<name>`                                   |                             |
+
+</div>
+
+## Help & History
+
+<div className="center">
+
+| **Description**       | **Bash Command** | **PowerShell Equivalent**        | **Notes**                         |
+| :-------------------- | ---------------- | :------------------------------- | :-------------------------------- |
+| Show command help     | `man <command>`  | `Get-Help <command>`             | Add `-Online` to open in browser. |
+| Show command history  | `history`        | `Get-History`                    |                                   |
+| Clear terminal screen | `clear`          | `Clear-Host` or `clear` or `cls` | `clear` and `cls` are aliases.    |
+
+</div>
+
+## Pipes & Redirection
+
+<div className="center">
+
+| **Description**                 | **Bash Command**           | **PowerShell Equivalent**            | **Notes**                                           |
+| :------------------------------ | :------------------------- | :----------------------------------- | :-------------------------------------------------- |
+| Pipe output to file (overwrite) | `<command> > <file>`       | `<command> \| Out-File <file>`       |                                                     |
+| Pipe output to file (append)    | `<command> >> <file>`      | `command \| Out-File -Append <file>` |                                                     |
+| Pipe to another command         | `<command1> \| <command2>` | `<command1> \| <command2>`           | Works the same, but passes objects instead of text. |
+
+</div>
+
+## Process Management
+
+<div className="center">
+
+| **Description**          | **Bash Command**        | **PowerShell Equivalent**                | **Notes**           |
+| :----------------------- | :---------------------- | :--------------------------------------- | :------------------ |
+| Show running processes   | `ps aux`                | `Get-Process`                            |                     |
+| Search processes by name | `ps aux \| grep <name>` | `Get-Process -Name <name>`               | Supports wildcards  |
+| Kill process by name     | `killall <name>`        | `Stop-Process -Name <name>`              | Supports wildcards  |
+| Kill process by PID      | `kill <PID>`            | `Stop-Process -Id <PID>` or `kill <PID>` | `kill` is an alias. |
+
+</div>
+
+## Permissions
+
+<div className="center">
+
+| **Description**    | **Bash Command**    | **PowerShell Equivalent** | **Notes**                       |
+| :----------------- | :------------------ | :------------------------ | :------------------------------ |
+| Change permissions | `chmod 644 <file>`  | _(No direct equivalent)_  | Windows uses ACLs instead.      |
+| Change ownership   | `chown user <file>` | _(No direct equivalent)_  | Requires `icacls` or `Set-Acl`. |
+
+</div>

--- a/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
+++ b/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
@@ -67,7 +67,7 @@ PowerShell equivalents.
 | :----------------- | :---------------------------- | :---------------------------------------------- | :------------------------- |
 | Find files by name | `find . -name <name/pattern>` | `Get-ChildItem -Recurse -Filter <name/pattern>` |                            |
 | Search inside file | `grep <pattern> <file>`       | `Select-String <pattern> <file>`                | Supports regex by default. |
-| Search recursively | `grep -r <pattern> .`         | `Select-String -Recurse <pattern> -Path . `     |                            |
+| Search recursively | `grep -r <pattern> .`         | `Select-String -Recurse <pattern> -Path .`      |                            |
 
 </div>
 
@@ -100,11 +100,11 @@ PowerShell equivalents.
 
 <div className="center">
 
-| **Description**                 | **Bash Command**           | **PowerShell Equivalent**            | **Notes**                                           |
-| :------------------------------ | :------------------------- | :----------------------------------- | :-------------------------------------------------- |
-| Pipe output to file (overwrite) | `<command> > <file>`       | `<command> \| Out-File <file>`       |                                                     |
+| **Description**                 | **Bash Command**           | **PowerShell Equivalent**              | **Notes**                                           |
+| :------------------------------ | :------------------------- | :------------------------------------- | :-------------------------------------------------- |
+| Pipe output to file (overwrite) | `<command> > <file>`       | `<command> \| Out-File <file>`         |                                                     |
 | Pipe output to file (append)    | `<command> >> <file>`      | `<command> \| Out-File -Append <file>` |                                                     |
-| Pipe to another command         | `<command1> \| <command2>` | `<command1> \| <command2>`           | Works the same, but passes objects instead of text. |
+| Pipe to another command         | `<command1> \| <command2>` | `<command1> \| <command2>`             | Works the same, but passes objects instead of text. |
 
 </div>
 

--- a/books/powershell/index.mdx
+++ b/books/powershell/index.mdx
@@ -1,5 +1,27 @@
-import ConstructionAnimation from "@site/src/components/ConstructionAnimation";
+---
+title: PowerShell
+description: A collection of PowerShell resources and guides.
+date: 2025-08-12T00:00:00Z
+tags:
+  - bash
+  - cheat-sheet
+  - linux
+  - productivity
+  - scripting
+  - sysadmin
+  - windows
+---
+
+import { PowerShell } from "@site/src/assets/devicon";
+
+<PowerShell width={256} height={256} />
 
 # PowerShell
 
-<ConstructionAnimation />
+PowerShell is a powerful scripting language and command-line shell designed for
+system administration and automation. Below are some useful resources and guides
+to help you get started with PowerShell:
+
+- [**Bash to PowerShell: Commands Cheat Sheet**](/writings/books/powershell/bash-to-powershell-commands-cheat-sheet) -
+  A quick reference guide for converting common Bash commands to their
+  PowerShell equivalents.

--- a/books/powershell/index.mdx
+++ b/books/powershell/index.mdx
@@ -19,9 +19,9 @@ import { PowerShell } from "@site/src/assets/devicon";
 # PowerShell
 
 PowerShell is a powerful scripting language and command-line shell designed for
-system administration and automation. Below are some useful resources and guides
-to help you get started with PowerShell:
+system administration and automation. Below are some useful resources and
+guides:
 
 - [**Bash to PowerShell: Commands Cheat Sheet**](/writings/books/powershell/bash-to-powershell-commands-cheat-sheet) -
-  A quick reference guide for converting common Bash commands to their
-  PowerShell equivalents.
+  A quick reference guide of common Bash commands to their PowerShell
+  equivalents.

--- a/books/powershell/sidebar.ts
+++ b/books/powershell/sidebar.ts
@@ -9,7 +9,7 @@ const sidebar: SidebarsConfig = {
         type: "doc",
         id: "index",
       },
-      items: [],
+      items: ["bash-to-powershell-commands-cheat-sheet/index"],
     },
   ],
 };

--- a/books/powershell/tags.yml
+++ b/books/powershell/tags.yml
@@ -1,0 +1,24 @@
+bash:
+  label: Bash
+  permalink: /bash
+  description: A collection of Bash related resources.
+
+cheat-sheet:
+  label: Cheat Sheet
+  permalink: /cheat-sheet
+  description: Quick reference guides for various commands and tasks.
+
+productivity:
+  label: Productivity
+  permalink: /productivity
+  description: Tips and tools to enhance productivity.
+
+scripting:
+  label: Scripting
+  permalink: /scripting
+  description: Resources and guides for scripting.
+
+sysadmin:
+  label: Sysadmin
+  permalink: /sysadmin
+  description: System administration resources and tools.

--- a/books/powershell/tags.yml
+++ b/books/powershell/tags.yml
@@ -8,6 +8,11 @@ cheat-sheet:
   permalink: /cheat-sheet
   description: Quick reference guides for various commands and tasks.
 
+linux:
+  label: Linux
+  permalink: /linux
+  description: Resources and guides for Linux systems.
+
 productivity:
   label: Productivity
   permalink: /productivity
@@ -22,3 +27,8 @@ sysadmin:
   label: Sysadmin
   permalink: /sysadmin
   description: System administration resources and tools.
+
+windows:
+  label: Windows
+  permalink: /windows
+  description: Resources and guides for Windows systems.

--- a/books/powershell/tags.yml
+++ b/books/powershell/tags.yml
@@ -24,7 +24,7 @@ scripting:
   description: Resources and guides for scripting.
 
 sysadmin:
-  label: Sysadmin
+  label: System Administration
   permalink: /sysadmin
   description: System administration resources and tools.
 


### PR DESCRIPTION
## 🎯 Purpose

Introduce a comprehensive cheat sheet for Bash to PowerShell command equivalents, enhancing user productivity during transitions. Add initial tags configuration for better resource organization and accessibility.

## 💡 Notes

No breaking changes introduced.