### PR TITLE
📝 docs: update environment variable commands in PowerShell cheat sheet

### DIFF
--- a/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
+++ b/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
@@ -75,12 +75,12 @@ PowerShell equivalents.
 
 <div className="center">
 
-| **Description**                  | **Bash Command**          | **PowerShell Equivalent**                       | **Notes**                   |
-| :------------------------------- | :------------------------ | :---------------------------------------------- | :-------------------------- |
-| Show command path                | `which <command>`         | `Get-Command <command> \| Select-Object Source` | Shows full path to command. |
-| Show environment variables       | `printenv`                | `Get-ChildItem Env:`                            |                             |
-| Set environment variable         | `export <name>="<value>"` | `$Env:<name> = "<value>"`                       |                             |
-| Show single environment variable | `echo $<name>`            | `$Env:<name>`                                   |                             |
+| **Description**                  | **Bash Command**                                                                                                 | **PowerShell Equivalent**                       | **Notes**                   |
+| :------------------------------- | :--------------------------------------------------------------------------------------------------------------- | :---------------------------------------------- | :-------------------------- |
+| Show command path                | `which <command>`                                                                                                | `Get-Command <command> \| Select-Object Source` | Shows full path to command. |
+| Show environment variables       | `printenv`                                                                                                       | `Get-ChildItem Env:`                            |                             |
+| Set environment variable         | <span style={{ fontVariantLigatures: "none" }}><code>export &lt;name&gt;=&quot;&lt;value&gt;&quot;</code></span> | `$Env:<name> = "<value>"`                       |                             |
+| Show single environment variable | `echo $<name>`                                                                                                   | `$Env:<name>`                                   |                             |
 
 </div>
 

--- a/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
+++ b/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
@@ -75,12 +75,12 @@ PowerShell equivalents.
 
 <div className="center">
 
-| **Description**                  | **Bash Command**                                                                                 | **PowerShell Equivalent**                       | **Notes**                   |
-| :------------------------------- | :----------------------------------------------------------------------------------------------- | :---------------------------------------------- | :-------------------------- |
-| Show command path                | `which <command>`                                                                                | `Get-Command <command> \| Select-Object Source` | Shows full path to command. |
-| Show environment variables       | `printenv`                                                                                       | `Get-ChildItem Env:`                            |                             |
-| Set environment variable         | <span className="no-ligatures"><code>export &lt;name&gt;=&quot;&lt;value&gt;&quot;</code></span> | `$Env:<name> = "<value>"`                       |                             |
-| Show single environment variable | `echo $<name>`                                                                                   | `$Env:<name>`                                   |                             |
+| **Description**                  | **Bash Command**                                                | **PowerShell Equivalent**                       | **Notes**                   |
+| :------------------------------- | :-------------------------------------------------------------- | :---------------------------------------------- | :-------------------------- |
+| Show command path                | `which <command>`                                               | `Get-Command <command> \| Select-Object Source` | Shows full path to command. |
+| Show environment variables       | `printenv`                                                      | `Get-ChildItem Env:`                            |                             |
+| Set environment variable         | <span className="no-ligatures">`export <name>="<value>"`</span> | `$Env:<name> = "<value>"`                       |                             |
+| Show single environment variable | `echo $<name>`                                                  | `$Env:<name>`                                   |                             |
 
 </div>
 

--- a/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
+++ b/books/powershell/bash-to-powershell-commands-cheat-sheet/index.mdx
@@ -75,12 +75,12 @@ PowerShell equivalents.
 
 <div className="center">
 
-| **Description**                  | **Bash Command**                                                                                                 | **PowerShell Equivalent**                       | **Notes**                   |
-| :------------------------------- | :--------------------------------------------------------------------------------------------------------------- | :---------------------------------------------- | :-------------------------- |
-| Show command path                | `which <command>`                                                                                                | `Get-Command <command> \| Select-Object Source` | Shows full path to command. |
-| Show environment variables       | `printenv`                                                                                                       | `Get-ChildItem Env:`                            |                             |
-| Set environment variable         | <span style={{ fontVariantLigatures: "none" }}><code>export &lt;name&gt;=&quot;&lt;value&gt;&quot;</code></span> | `$Env:<name> = "<value>"`                       |                             |
-| Show single environment variable | `echo $<name>`                                                                                                   | `$Env:<name>`                                   |                             |
+| **Description**                  | **Bash Command**                                                                                 | **PowerShell Equivalent**                       | **Notes**                   |
+| :------------------------------- | :----------------------------------------------------------------------------------------------- | :---------------------------------------------- | :-------------------------- |
+| Show command path                | `which <command>`                                                                                | `Get-Command <command> \| Select-Object Source` | Shows full path to command. |
+| Show environment variables       | `printenv`                                                                                       | `Get-ChildItem Env:`                            |                             |
+| Set environment variable         | <span className="no-ligatures"><code>export &lt;name&gt;=&quot;&lt;value&gt;&quot;</code></span> | `$Env:<name> = "<value>"`                       |                             |
+| Show single environment variable | `echo $<name>`                                                                                   | `$Env:<name>`                                   |                             |
 
 </div>
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -113,6 +113,10 @@ article h6,
   display: inline-block;
 }
 
+.no-ligatures {
+  font-variant-ligatures: none;
+}
+
 .reference-text {
   color: var(--ifm-font-color-base);
 }


### PR DESCRIPTION
## 🎯 Purpose

Revise the environment variable commands in the PowerShell documentation for clarity and consistency due to font variant ligatures issue. The Bash command for setting an environment variable now uses HTML entities for better rendering, aiding users transitioning from Bash to PowerShell.

## 💡 Notes

No breaking changes introduced. Changes enhance documentation readability.