### PR TITLE
📝 docs: improve clarity in section titles and update documentation

### DIFF
--- a/books/wonders/index.mdx
+++ b/books/wonders/index.mdx
@@ -28,10 +28,6 @@ tools, libraries, or anything that is useful.
 
 - [**Design Resources**](/writings/books/wonders/design-resources): A collection
   of design resources including icons, graphics, and more.
-  - [**Emoji Sets**](/writings/books/wonders/design-resources#emoji-sets): A
-    collection of emoji sets that can be used in various contexts.
 - [**Development Tools**](/writings/books/wonders/development-tools): A list of
   development tools including text editors, IDEs, and other utilities that
   enhance productivity and streamline the coding process.
-  - [**Text Editors**](/writings/books/wonders/development-tools#text-editors):
-    A list of text editors along with their features and benefits.

--- a/sections/writings/books/index.mdx
+++ b/sections/writings/books/index.mdx
@@ -53,7 +53,7 @@ export const iconHeight = 64;
 
 ---
 
-## Cloud, Infrastructure, System, & Virtualization
+## Cloud, Infrastructure, Systems, & Virtualization
 
 <InfoCardHorizontal
   to="/writings/books/linux"


### PR DESCRIPTION
## 🎯 Purpose

Corrected a section title for clarity and removed references to emoji sets and text editors from the documentation.

## 💡 Notes

No breaking changes introduced.