### PR TITLE
🎨 style: update imageZoom background color for consistency

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -310,7 +310,7 @@ const config: Config = {
     imageZoom: {
       selector: ".markdown img",
       options: {
-        background: "var(--ifm-background-color)",
+        background: "#1b1b1d",
       },
     },
     image: socialCard,


### PR DESCRIPTION
## 🎯 Purpose

Change the background color of the imageZoom options in the Docusaurus configuration to a specific hex value for a consistent appearance across the site.

## 💡 Notes

No breaking changes introduced.