### PR TITLE
🔧 chore: remove social links from config

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -330,16 +330,6 @@ const config: Config = {
         },
         {
           position: "right",
-          label: "Email",
-          href: "mailto:imfsiddiqui@yahoo.com",
-        },
-        {
-          position: "right",
-          label: "LinkedIn",
-          href: "https://www.linkedin.com/in/imfsiddiqui",
-        },
-        {
-          position: "right",
           label: "Socials",
           to: "/socials/",
         },


### PR DESCRIPTION
## 🎯 Purpose

Removed Email and LinkedIn links from the Docusaurus configuration to streamline navigation options and improve user experience.

## 💡 Notes

No breaking changes introduced.